### PR TITLE
fixed saveToDisk mishap by moving saveToDisk() to only top level calls

### DIFF
--- a/lib/src/Credentials/trash-can/credential_list_view.dart
+++ b/lib/src/Credentials/trash-can/credential_list_view.dart
@@ -30,6 +30,7 @@ class _CredentialTrashListWidget extends State<CredentialTrashListWidget> {
     setState(() {
       credentials.remove(credential.uuid);
       credentialList = credentials.deletedList.values.toList();
+      credentials.saveToDisk();
     });
   }
 

--- a/lib/src/Folders/folder_list.dart
+++ b/lib/src/Folders/folder_list.dart
@@ -28,7 +28,6 @@ class FolderList {
   void add(Folder folder) {
     byIDList[folder.uuid!] = folder;
     byNameList[folder.displayName] = folder;
-    saveToDisk();
   }
 
   /// remove Folder with ID [folderUUID] from this FolderList
@@ -37,7 +36,6 @@ class FolderList {
     if (temp != null) {
       byIDList.remove(folderUUID);
       byNameList.remove(temp.displayName);
-      saveToDisk();
     }
   }
 

--- a/lib/src/Folders/folder_list_view_widget.dart
+++ b/lib/src/Folders/folder_list_view_widget.dart
@@ -43,6 +43,7 @@ class _FolderListWidget extends State<FolderListWidget> {
       onDeleteCallback: ({required bool recursive, required String uuid}) {
         setState(() {
           folders.remove(uuid);
+          folders.saveToDisk();
           folderList = folders.byIDList.values.toList();
           widget.onDeleteCallback(recursive);
         });

--- a/lib/src/Folders/folder_view.dart
+++ b/lib/src/Folders/folder_view.dart
@@ -24,6 +24,7 @@ class _FolderView extends State<FolderView> {
   void addToCredentials(Credential credential) {
     setState(() {
       data.credentials.add(credential);
+      data.credentials.saveToDisk();
     });
   }
 

--- a/lib/src/Widgets/home_all_credentials_display.dart
+++ b/lib/src/Widgets/home_all_credentials_display.dart
@@ -30,6 +30,7 @@ class _HomeCredentialsDisplayWidget
   void addToCredentials(Credential credential) {
     setState(() {
       _combinedData.credentials!.add(credential);
+      _combinedData.credentials!.saveToDisk();
     });
   }
 

--- a/lib/src/Widgets/home_folders_display.dart
+++ b/lib/src/Widgets/home_folders_display.dart
@@ -34,6 +34,7 @@ class _HomeFoldersDisplayWidget extends State<HomeFoldersDisplayWidget> {
   void addFolderToList(Folder folder) {
     setState(() {
       _combinedData.folders!.add(folder);
+      _combinedData.folders!.saveToDisk();
     });
   }
 


### PR DESCRIPTION
That way the race condition of partial file overwriting should be unable to be hit by the user