### PR TITLE
fix url not being stored to proper sharedPreferences

### DIFF
--- a/lib/src/Auth/login_controller.dart
+++ b/lib/src/Auth/login_controller.dart
@@ -1,3 +1,4 @@
+import 'package:anonkey_frontend/Utility/api_base_data.dart';
 import 'package:anonkey_frontend/Utility/notification_popup.dart';
 import 'package:anonkey_frontend/api/lib/api.dart';
 import 'package:anonkey_frontend/src/Auth/login_view.dart';
@@ -128,11 +129,8 @@ class LoginController extends State<LoginView> {
         );
 
         if (test) {
-          SharedPreferences prefs = await SharedPreferences.getInstance();
-          await prefs.setString(
-            'url',
-            url.text,
-          ); // Ensure the preferences are saved
+          await ApiBaseData.setURL(url.text);
+          // Ensure the preferences are saved
           if (!mounted) return;
           context.goNamed("home");
         } else {

--- a/lib/src/Auth/register_controller.dart
+++ b/lib/src/Auth/register_controller.dart
@@ -1,3 +1,4 @@
+import 'package:anonkey_frontend/Utility/api_base_data.dart';
 import 'package:anonkey_frontend/Utility/notification_popup.dart';
 import 'package:anonkey_frontend/api/lib/api.dart';
 import 'package:anonkey_frontend/src/Auth/register_view.dart';
@@ -146,8 +147,7 @@ class RegisterControllerState extends State<RegisterView> {
           url.text,
         );
         if (isRegistered) {
-          final SharedPreferences prefs = await SharedPreferences.getInstance();
-          prefs.setString('url', url.text);
+          await ApiBaseData.setURL(url.text);
           if (!mounted) return;
           context.goNamed('home');
         }


### PR DESCRIPTION
This sets the register and login page to use apiBaseData.
This will fix an error caused by previously using the old SharedPreferences lib and apiBaseData using the new SharedPreferencesAsync lib.

This resulted in the release being unusable